### PR TITLE
NH-76572 - Fixed packaging url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ cpp:
 go:
 	@echo "Generating apm-library package for Go"
 	@docker run --user `id -u` --rm -v $(PWD):/defs namely/protoc-all:1.51_1 -d . -l go -o go
-	@docker run --rm -v "${PWD}":/apm-proto -w /apm-proto/go/collectorpb golang:1.21.0 sh -c "go mod init github.com/solarwinds/apm-proto/go/collectorpb && go mod tidy"
+	@docker run --rm -v "${PWD}":/apm-proto -w /apm-proto/go/collectorpb golang:1.21.0 sh -c "go mod init github.com/solarwindscloud/apm-proto/go/collectorpb && go mod tidy"
 	@docker run --user `id -u` --rm -v "${PWD}/go/collectorpb":/src -w /src vektra/mockery --all --case=underscore
 	@rm -rf go/collectorpb/go.*
 

--- a/go/collectorpb/mocks/trace_collector_client.go
+++ b/go/collectorpb/mocks/trace_collector_client.go
@@ -5,7 +5,7 @@ package mocks
 import (
 	context "context"
 
-	collectorpb "github.com/solarwinds/apm-proto/go/collectorpb"
+	collectorpb "github.com/solarwindscloud/apm-proto/go/collectorpb"
 
 	grpc "google.golang.org/grpc"
 

--- a/go/collectorpb/mocks/trace_collector_server.go
+++ b/go/collectorpb/mocks/trace_collector_server.go
@@ -5,7 +5,7 @@ package mocks
 import (
 	context "context"
 
-	collectorpb "github.com/solarwinds/apm-proto/go/collectorpb"
+	collectorpb "github.com/solarwindscloud/apm-proto/go/collectorpb"
 
 	mock "github.com/stretchr/testify/mock"
 )


### PR DESCRIPTION
### Description of changes:
- Fixed the package url as the tagged version sit in github.com/solarwindscloud/apm-proto

https://pkg.go.dev/github.com/solarwindscloud/apm-proto/go/collectorpb?tab=versions

### Related issues #
[NH-76572](https://swicloud.atlassian.net/browse/NH-76572)


[NH-76572]: https://swicloud.atlassian.net/browse/NH-76572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ